### PR TITLE
Unterstützung für favorisierte Kommentare und Inaktivität hinzugefügt

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -61,6 +61,7 @@ export enum Vote {
 	Down = -1,
 	None = 0,
 	Up = 1,
+	Favorisieren = 2,
 }
 
 export enum ItemFlags {
@@ -116,6 +117,15 @@ export interface ProfileComment extends Comment {
 	thumb: ThumbnailURL;
 }
 
+export interface LikedProfileComment extends Comment {
+	itemId: ItemID;
+	thumb: ThumbnailURL;
+	ccreated: Timestamp; // Timestamp wann der Kommentar als Favorit markiert wurde
+	mark: UserMark;
+	userId: UserID;
+	name: Username;
+}
+
 export interface CommentUser {
 	id: UserID;
 	name: Username;
@@ -130,6 +140,7 @@ export interface User extends CommentUser {
 	bannedUntil?: Timestamp;
 	itemDelete: number;
 	commentDelete: number;
+	inactive: boolean;
 }
 
 export interface FollowedUser {

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -30,7 +30,8 @@ export interface GetProfileInfoResponse extends Pr0grammResponse {
 	user: Types.User;
 	comments: Types.ProfileComment[];
 	commentCount: number;
-	// TODO: comments_likes
+	commentLikesCount: number;
+	comments_likes: Types.LikedProfileComment[];
 	uploads: Types.ProfileUpload[];
 	uploadCount: number;
 	likesArePublic: boolean;


### PR DESCRIPTION
Ich habe Mal die favorisierten Kommentare und die Anzahl davon hinzugefügt. Ebenfalls ob der Benutzer wegen Inaktivität gebannt wurde.

Bei Vote habe ich das **_Favorisieren_** hinzugefügt. Mittels der 2 kann man dem Kommentar oder Post ein Upvote geben und ihn zu den Favoriten hinzufügen. Um den Kommentar/Post wieder zu entfernen einfach Downvoten, nur ein simples Upvote geben oder den Vote entfernen.