### PR TITLE
Hinzufügen der Benachrichtungen für neue Kommentare

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -294,3 +294,25 @@ export interface Message {
 	created: UnixTimestamp;
 	message: string;
 }
+
+export interface InboxComments {
+	type: string;
+	id: CommentID;
+	itemId: ItemID;
+	image: ImageURL;
+	thumb: ThumbnailURL;
+	flags: ItemFlags;
+	name: Username;
+	mark: UserMark;
+	senderId: UserID;
+	score: Score;
+	collection?: null;
+	owner?: null;
+	ownerMark?: null;
+	keyword?: null;
+	created: Timestamp;
+	message: string;
+	read: number;
+	blocked: number;
+}
+  

--- a/src/pr0gramm-api.ts
+++ b/src/pr0gramm-api.ts
@@ -309,6 +309,16 @@ export class Pr0grammMessageService {
 	constructor(private readonly requester: APIRequester) {
 	}
 
+	public getComments(): Promise<Response.InboxCommentsResponse> {
+		const path = `/inbox/comments`;
+		return this.requester.get(path);
+	}
+
+	public getCommentsOlder(older: Types.Timestamp): Promise<Response.InboxCommentsResponse> {
+		const path = `/inbox/comments`;
+		return this.requester.get(path, { older });
+	}
+
 	public getConversations(): Promise<Response.ConversationResponse> {
 		const path = `/inbox/conversations`;
 		return this.requester.get(path);

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -108,6 +108,10 @@ export interface ConversationResponse extends Pr0grammResponse {
 	atEnd: boolean;
 }
 
+export interface InboxCommentsResponse extends Pr0grammResponse {
+	messages: Types.InboxComments[];
+}
+
 export interface MessagesResponse extends Pr0grammResponse {
 	messages: Types.Message[];
 	atEnd: boolean;


### PR DESCRIPTION
Ich brauche diese Funktion in einem Projekt von mir und habe die Chance gleich genutzt diese auch in die Repo hinzuzufügen.

Was
```typescript
	collection?: null;
	owner?: null;
	ownerMark?: null;
	keyword?: null;
```
sind, weiß ich nicht. Habe dazu nichts Brauchbares gefunden.