### PR TITLE
Added missing DeleteConversation API endpoint

### DIFF
--- a/src/pr0gramm-api.ts
+++ b/src/pr0gramm-api.ts
@@ -275,6 +275,10 @@ export class Pr0grammMessageService {
 	constructor(private readonly requester: APIRequester) {
 	}
 
+	deleteConversation(recipientName: Types.Username): Promise<Response.Pr0grammResponse> {
+        return this.requester.post("/inbox/deleteConversation", { recipientName });
+    }
+
 	getComments(): Promise<Response.InboxCommentsResponse> {
 		return this.requester.get("/inbox/comments");
 	}


### PR DESCRIPTION
Moin,

mein Bot verschickt Fehlermeldungen etc. per PN. Da sich über die Zeit einiges ansammeln wird, würde ich gerne per Job alle 24 Stunden Konversationen/Nachrichten älter x Tage löschen. 

Hierfür der (bisher fehlende) neue API Endpoint.

Peace